### PR TITLE
Feature: Add alternative base branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-9](https://github.com/rimi-itk/gh-itkdev/pull/9)
+  Added alternative base branches
 * [PR-7](https://github.com/rimi-itk/gh-itkdev/pull/7)
   Fixed URL parsing
 

--- a/changelog/release.go
+++ b/changelog/release.go
@@ -13,21 +13,14 @@ import (
 	"time"
 )
 
-func createReleaseBranch(release string, baseBranches []string) (string, error) {
-	if len(baseBranches) == 0 {
-		return "", fmt.Errorf("All attempts to create the release branch failed.")
-	}
-
+func createReleaseBranch(release string, base string) (string, error) {
 	branch := "release/" + release
-	base := baseBranches[0]
-
 	cmd := exec.Command("git", "checkout", "-b", branch, base)
-	_, err := cmd.CombinedOutput()
-
-	//if error occurred, retry with next base
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return createReleaseBranch(release, baseBranches[1:])
+		return "", fmt.Errorf("%s: %s", output, err)
 	}
+
 	return branch, nil
 }
 
@@ -118,7 +111,7 @@ func updateReleaseChangelog(changelog string, release string) (string, error) {
 	return strings.Join(lines, "\n") + "\n", nil
 }
 
-func Release(release string, baseBranches []string, name string, commit bool) {
+func Release(release string, base string, name string, commit bool) {
 	b, err := os.ReadFile(name)
 	if err != nil {
 		log.Fatal(err)
@@ -130,7 +123,7 @@ func Release(release string, baseBranches []string, name string, commit bool) {
 		log.Fatal(err)
 	}
 
-	branch, err := createReleaseBranch(release, baseBranches)
+	branch, err := createReleaseBranch(release, base)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -15,9 +15,9 @@ var (
 	pullRequestItemTemplate string = `* [PR-{{ .Number }}]({{ .Url }})
   {{ .Title }}`
 
-	release    string
-	baseBranch string = "develop"
-	commit     bool   = false
+	release      string
+	baseBranches      = []string{"develop", "main", "master"}
+	commit       bool = false
 
 	changelogName string = "CHANGELOG.md"
 
@@ -30,7 +30,7 @@ var (
 			} else if fuckingChangelog {
 				changelog.FuckingChangelog(changelogName, pullRequestItemTemplate)
 			} else if release != "" {
-				changelog.Release(release, baseBranch, changelogName, commit)
+				changelog.Release(release, baseBranches, changelogName, commit)
 			} else {
 				cmd.Usage()
 			}
@@ -47,7 +47,7 @@ func init() {
 	changelogCmd.Flags().StringVarP(&pullRequestItemTemplate, "item-template", "", pullRequestItemTemplate, "pull request item template")
 
 	changelogCmd.Flags().StringVarP(&release, "release", "", "", "create a release branch with updated changelog")
-	changelogCmd.Flags().StringVarP(&baseBranch, "base", "", baseBranch, "base branch for release")
+	changelogCmd.Flags().StringSliceVarP(&baseBranches, "base", "", baseBranches, "base branch for release")
 	changelogCmd.Flags().BoolVarP(&commit, "commit", "", commit, "commit changes")
 
 	changelogCmd.Flags().StringVarP(&changelogName, "changelog", "", changelogName, "changelog name")

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -19,7 +19,7 @@ var (
 	baseBranch string = func() string {
 		branches := []string{"develop", "main", "master"}
 		for _, branch := range branches {
-			cmd := exec.Command("git", "rev-parse", "--verify", "-b", branch)
+			cmd := exec.Command("git", "rev-parse", "--verify", "--branch", branch)
 			if _, err := cmd.CombinedOutput(); err == nil {
 				return branch
 			}


### PR DESCRIPTION
I ran into a project where "main" were the main branch. Since "develop" is the only predefined base branch, the release script did not work. I added an array of base branches, defined as ["develop", "main", "master"], to increase the success rate of the release script.

Apologies in advance - AI aided me with these changes, as i have yet to learn GO.

- **Updated baseBranch from string to array of strings**
- **Updated release script to handle array of base branches and try each one**
