### PR TITLE
Added format detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-11](https://github.com/rimi-itk/gh-itkdev/pull/11)
+  Added format detector
 * [PR-9](https://github.com/rimi-itk/gh-itkdev/pull/9)
   Added alternative base branches
 * [PR-7](https://github.com/rimi-itk/gh-itkdev/pull/7)

--- a/changelog/format_detector.go
+++ b/changelog/format_detector.go
@@ -1,0 +1,60 @@
+package changelog
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+)
+
+func DetectPullRequestEntryFormat(changelog string) (string, error) {
+	if _, err := os.Stat(changelog); err == nil {
+		b, err := os.ReadFile(changelog)
+		if err != nil {
+			return "", fmt.Errorf("cannot read file %s", changelog)
+		}
+		changelog = string(b)
+	}
+
+	templates := getPullRequestEntryTemplates()
+
+	for _, template := range templates {
+		if template.pattern.MatchString(changelog) {
+			return template.template, nil
+		}
+	}
+
+	if len(templates) < 1 {
+		return "", fmt.Errorf("cannot detect pull request entry format")
+	}
+
+	return templates[len(templates)-1].template, nil
+}
+
+func getPullRequestEntryTemplates() []struct {
+	pattern  *regexp.Regexp
+	template string
+} {
+	return []struct {
+		pattern  *regexp.Regexp
+		template string
+	}{
+		{
+			regexp.MustCompile("(?m)^- \\[PR-[0-9]+\\]\\([^)]+\\)\n  .+$"),
+			`- [PR-{{ .Number }}]({{ .Url }})
+  {{ .Title }}`,
+		},
+
+		{
+			regexp.MustCompile("(?m)^- \\[#[0-9]+\\]\\([^)]+\\)\n  .+$"),
+			`- [#{{ .Number }}]({{ .Url }})
+  {{ .Title }}`,
+		},
+
+		// The default – must come last.
+		{
+			regexp.MustCompile("."),
+			`* [PR-{{ .Number }}]({{ .Url }})
+  {{ .Title }}`,
+		},
+	}
+}

--- a/changelog/format_detector.go
+++ b/changelog/format_detector.go
@@ -23,10 +23,6 @@ func DetectPullRequestEntryFormat(changelog string) (string, error) {
 		}
 	}
 
-	if len(templates) < 1 {
-		return "", fmt.Errorf("cannot detect pull request entry format")
-	}
-
 	return templates[len(templates)-1].template, nil
 }
 
@@ -52,6 +48,7 @@ func getPullRequestEntryTemplates() []struct {
 
 		// The default – must come last.
 		{
+			// Match any non-empty changelog and provide a default template.
 			regexp.MustCompile("."),
 			`* [PR-{{ .Number }}]({{ .Url }})
   {{ .Title }}`,

--- a/changelog/format_detector_test.go
+++ b/changelog/format_detector_test.go
@@ -1,0 +1,44 @@
+package changelog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPullRequestTemplateDetector(t *testing.T) {
+	testCases := []struct {
+		changelog string
+		expected  string
+	}{
+		{
+			`- [PR-87](https://example.com/pr/87)
+  Test
+`,
+			`- [PR-{{ .Number }}]({{ .Url }})
+  {{ .Title }}`,
+		},
+
+		{
+			`- [#87](https://example.com/pr/87)
+  Test
+`,
+			`- [#{{ .Number }}]({{ .Url }})
+  {{ .Title }}`,
+		},
+
+		{
+			`* [PR-87](https://example.com/pr/87)
+  Test
+`,
+			`* [PR-{{ .Number }}]({{ .Url }})
+  {{ .Title }}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		actual, _ := DetectPullRequestEntryFormat(testCase.changelog)
+
+		assert.Equal(t, testCase.expected, actual)
+	}
+}

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os/exec"
+
 	"github.com/rimi-itk/gh-itkdev/changelog"
 	"github.com/spf13/cobra"
-	"os/exec"
 )
 
 // changelogCmd represents the changelog command
@@ -12,8 +13,11 @@ var (
 	create bool
 
 	fuckingChangelog        bool
-	pullRequestItemTemplate string = `* [PR-{{ .Number }}]({{ .Url }})
-  {{ .Title }}`
+	pullRequestItemTemplate string = func() string {
+		format, _ := changelog.DetectPullRequestEntryFormat(changelogName)
+
+		return format
+	}()
 
 	release    string
 	baseBranch string = func() string {


### PR DESCRIPTION
We don't use the same pull request entry format in our changelogs across projects. This adds a “changelog format detector” that can help detect the format used in a project. Currently, three formats observed in the wild are supported:

1. Exhibit 1 (e.g. https://github.com/itk-dev/ai-screening/blob/develop/CHANGELOG.md):

        - [PR-87](https://example.com/pr/87)
          Test

2. Exhibit 2 (e.g. https://github.com/itk-dev/devops_itksites/blob/develop/CHANGELOG.md):

        - [#87](https://example.com/pr/87)
          Test

3. Exhibit 3 (e.g. https://github.com/itk-dev/hoeringsportal/blob/develop/CHANGELOG.md):

        * [PR-87](https://example.com/pr/87)
          Test

