### PR TITLE
Transfer project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* [PR-11](https://github.com/rimi-itk/gh-itkdev/pull/11)
+* [PR-11](https://github.com/itk-dev/gh-itkdev/pull/11)
   Added format detector
-* [PR-9](https://github.com/rimi-itk/gh-itkdev/pull/9)
+* [PR-9](https://github.com/itk-dev/gh-itkdev/pull/9)
   Added alternative base branches
-* [PR-7](https://github.com/rimi-itk/gh-itkdev/pull/7)
+* [PR-7](https://github.com/itk-dev/gh-itkdev/pull/7)
   Fixed URL parsing
 
 ## [v0.0.1] - 2024-04-03
 
-* [PR-6](https://github.com/rimi-itk/gh-itkdev/pull/6)
+* [PR-6](https://github.com/itk-dev/gh-itkdev/pull/6)
   Bugfix
-* [PR-5](https://github.com/rimi-itk/gh-itkdev/pull/5)
+* [PR-5](https://github.com/itk-dev/gh-itkdev/pull/5)
   Updated usage documentation
 
 ## [v0.0.0] - 2024-04-01
 
-* [PR-3](https://github.com/rimi-itk/gh-itkdev/pull/3)
+* [PR-3](https://github.com/itk-dev/gh-itkdev/pull/3)
   Added commit flag
-* [PR-2](https://github.com/rimi-itk/gh-itkdev/pull/2)
+* [PR-2](https://github.com/itk-dev/gh-itkdev/pull/2)
   Added changelog command
 
 [Unreleased]: https://github.com/compare/v0.0.1...HEAD

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 ## Installation
 
 ```shell
-gh extension install rimi-itk/gh-itkdev
+gh extension install itk-dev/gh-itkdev
 ```
 
-**Note**: This may not (yet) work (cf. <https://github.com/rimi-itk/gh-itkdev/actions/workflows/release.yml>) and you
+**Note**: This may not (yet) work (cf. <https://github.com/itk-dev/gh-itkdev/actions/workflows/release.yml>) and you
 may have to [install from source](#installing-from-source).
 
 ### Installing from source
@@ -16,11 +16,14 @@ may have to [install from source](#installing-from-source).
 Assuming [Go is installed](https://go.dev/doc/install), you can [install from
 source](https://cli.github.com/manual/gh_extension_install) by running
 
-``` shell
-git clone https://github.com/rimi-itk/gh-itkdev /tmp/gh-itkdev
+``` shell name="build-and-install"
+gh extension remove itkdev
+rm -fr /tmp/gh-itkdev
+git clone https://github.com/itk-dev/gh-itkdev /tmp/gh-itkdev
 cd /tmp/gh-itkdev
 task build
 gh extension install .
+cd -
 ```
 
 ## Usage

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 
-	"github.com/rimi-itk/gh-itkdev/changelog"
+	"github.com/itk-dev/gh-itkdev/changelog"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rimi-itk/gh-itkdev
+module github.com/itk-dev/gh-itkdev
 
 go 1.22
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/rimi-itk/gh-itkdev/cmd"
+import "github.com/itk-dev/gh-itkdev/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Changes repository owner from `rimi-itk` to `itk-dev` and updates “Installing from source” section.