### PR TITLE
feat: Release branch naming convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* [PR-19](https://github.com/itk-dev/gh-itkdev/pull/19)
+  Always use release/{version} branch naming convention
 * [PR-16](https://github.com/itk-dev/gh-itkdev/pull/16)
   Added version check to determine release type
 * [PR-15](https://github.com/itk-dev/gh-itkdev/pull/15)

--- a/changelog/release.go
+++ b/changelog/release.go
@@ -24,15 +24,9 @@ func getBranchName(release string) (string, error) {
 		return "", fmt.Errorf("invalid version: %s", release)
 	}
 
-	branchType := "release"
-	// Determine if the release is a "release" or a "hotfix".
-	//
-	// A "hotfix" is a version that's not a prerelease and has a patch version different from 0 (cf. https://semver.org/).
-	if semver.Prerelease(version) == "" && semver.MajorMinor(version)+".0" != version {
-		branchType = "hotfix"
-	}
-
-	return branchType + "/" + release, nil
+	// Our default Woodpecker setup only triggers on release/* branches,
+	// so always use that naming scheme, regardless of the nature of the change.
+	return "release/" + release, nil
 }
 
 func createReleaseBranch(release string, base string) (string, error) {

--- a/changelog/release_test.go
+++ b/changelog/release_test.go
@@ -26,7 +26,7 @@ func TestBranchName(t *testing.T) {
 		},
 		{
 			"v0.0.1",
-			"hotfix/v0.0.1",
+			"release/v0.0.1",
 			"",
 		},
 		{


### PR DESCRIPTION
Using
gh itkdev changelog --release x.x.x to create a new patch release, the release branch is named hotfix/x.x.x

Due to the default woodpecker staging release setup, this will not trigger a release to staging.

Therefore, i propose that we only use the release/x.x.x naming convention, even if the original solution is more correct.

Updating the changelog manually is i pain, i love this tool 🫶